### PR TITLE
Process sequence tab

### DIFF
--- a/src/check_fastq.py
+++ b/src/check_fastq.py
@@ -27,7 +27,7 @@ def main():
         keys = ['s3://hca-util-upload-area/' + str(s3_object.key) for s3_object in my_bucket.objects.all()]
         filenames = [key for key in keys if uuid in key]
         filenames = filenames[1:]
-	filenames = [file for file in filenames if '.fastq.gz' in file]
+        filenames = [file for file in filenames if '.fastq.gz' in file]
 
         my_dict = {}
         for filename in filenames:

--- a/src/check_fastq.py
+++ b/src/check_fastq.py
@@ -27,6 +27,7 @@ def main():
         keys = ['s3://hca-util-upload-area/' + str(s3_object.key) for s3_object in my_bucket.objects.all()]
         filenames = [key for key in keys if uuid in key]
         filenames = filenames[1:]
+	filenames = [file for file in filenames if '.fastq.gz' in file]
 
         my_dict = {}
         for filename in filenames:

--- a/src/get_sequence_tab.py
+++ b/src/get_sequence_tab.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('file_name',type=str,help='path to file with the following columns: run,library,experiment,lib_protocol,seq_protocol')
+args = parser.parse_args()
+
+df = pd.read_csv(args.file_name,sep="\t")
+
+rows = [[list(df['run'])[i],list(df['library'])[i],list(df['experiment'])[i],list(df['lib_protocol'])[i],list(df['seq_protocol'])[i],list(df['run'])[i] + '_1.fastq.gz','read1'] for i in range(0,len(list(df['run'])))]
+df1 = pd.DataFrame(rows)
+
+rows = [[list(df['run'])[i],list(df['library'])[i],list(df['experiment'])[i],list(df['lib_protocol'])[i],list(df['seq_protocol'])[i],list(df['run'])[i] + '_2.fastq.gz','read2'] for i in range(0,len(list(df['run'])))]
+df2 = pd.DataFrame(rows)
+
+df3 = df1.append(df2)
+
+df3.to_csv('processed_sequence_tab.txt',sep='\t')


### PR DESCRIPTION
Added a small script to process the sequence tab rows. If fastq names are from ENA and the experiment and run accessions are available, this script will generate the correct number of rows and read index for the fastq names, alongside the associated accessions.