### PR TITLE
contributor aws account creation

### DIFF
--- a/docs/SOPs/dataset_wrangling_SOP.md
+++ b/docs/SOPs/dataset_wrangling_SOP.md
@@ -120,9 +120,21 @@ After the spreadsheet is generated some manual steps can help contributors under
 
 Once you have a customised and potentially pre-filled spreadsheet it can be sent to the contributor along with the contributor spreadsheet guide. It is generally an iterative process of the contributor filling in what they can, the wrangler reviewing, curating and asking questions before further curation until the metadata is complete. 
 
-## Raw data upload (fastq)
+## Raw Data Upload (fastq)
 
-In order for a contributor to upload their data, you will need to provide them with a data upload area UUID as well as a set of contributor AWS access keys. 
+In order for a contributor to upload their data, you will need to:
+
+- provide them with a data upload area UUID
+- create an AWS user for them
+  
+```shell
+# to add user alice as a contributor
+aws iam create-user --user-name alice --tags Key=project,Value=hca Key=owner,Value=tburdett Key=service,Value=ait
+aws iam add-user-to-group --group hca-contributor --user-name alice
+# generate secrets 
+aws iam create-access-key --user-name alice 
+```
+- provide them a set of contributor AWS access keys. 
 
 These two sets of information need to be sent separately to minimise the chance of them falling into the wrong hands and being misused.
 

--- a/docs/SOPs/dataset_wrangling_SOP.md
+++ b/docs/SOPs/dataset_wrangling_SOP.md
@@ -122,9 +122,12 @@ Once you have a customised and potentially pre-filled spreadsheet it can be sent
 
 ## Raw Data Upload (fastq)
 
-In order for a contributor to upload their data, you will need to:
+### AWS User for Contributors
 
-- provide them with a data upload area UUID
+In order for a contributor to upload their data, they would need their own AWS user that is assigned to the hca-contirbutor group. A dev would need to create the user for them using the commands listed below.
+
+### Data upload Procedure
+
 - create an AWS user for them
   
 ```shell
@@ -135,6 +138,7 @@ aws iam add-user-to-group --group hca-contributor --user-name alice
 aws iam create-access-key --user-name alice 
 ```
 - provide them a set of contributor AWS access keys. 
+- provide them with a data upload area UUID
 
 These two sets of information need to be sent separately to minimise the chance of them falling into the wrong hands and being misused.
 


### PR DESCRIPTION
We will go with an "aws account per contributor" approach.
I changed the docs to include the necessary commands.
If necessary, we can automate the email notification to the contributor.

Ticket #277