### PR TITLE
Improved name correction. Fixes #329

### DIFF
--- a/src/move_data_from_insdc.py
+++ b/src/move_data_from_insdc.py
@@ -157,8 +157,11 @@ def correct_filename_from_ena(run_accession, filename):
     else:
         return filename
 
-    # Search in the options
-    real_filename = next(real_name for real_name in filenames if f"R{read_index}" in real_name)
+    # Search in the options. If there are no results (Empty iterator), return filename.
+    try:
+        real_filename = next(real_name for real_name in filenames if f"R{read_index}" in real_name)
+    except StopIteration:
+        return filename
 
     # Correct the ".1" at the end
     real_filename = real_filename.split('.1')[0] if real_filename.endswith('.1') else real_filename

--- a/src/move_data_from_insdc.py
+++ b/src/move_data_from_insdc.py
@@ -161,6 +161,8 @@ def correct_filename_from_ena(run_accession, filename):
     try:
         real_filename = next(real_name for real_name in filenames if f"R{read_index}" in real_name)
     except StopIteration:
+        pass
+    finally:
         return filename
 
     # Correct the ".1" at the end


### PR DESCRIPTION
Improved the way the script `src/move_data_from_insdc` handles empty returns when looking for the correct filename in SRA (But downloads from ENA).

Now, instead of an empty `IterationStop` error, it will catch that and return the filename as stated in ENA (Usually an SRA accession followed by the read number)