### PR TITLE
Added new constraints on archiving to contributor communications

### DIFF
--- a/docs/SOPs/contributor_communication_SOP.md
+++ b/docs/SOPs/contributor_communication_SOP.md
@@ -109,7 +109,9 @@ Once a submission is 100% valid and has been reviewed, a final confirmation emai
 
 ## Confirmation of Accessions
 
-Once the submission has been successfully archived, accessions should be communicated back to the contributor. If there is a risk that the deadline the contributor gave will not be met, the contributor should be contacted to inform them of the risk and offer alternatives or work arounds. The project level accessions should be provided within the main body of the email.
+Once the submission has been successfully archived, accessions should be communicated back to the contributor. If there is a risk that the deadline the contributor gave will not be met, the contributor should be contacted to inform them of the risk and offer alternatives or workarounds. The project level accessions should be provided within the main body of the email.
+
+By default, the release date will be set up to 2 years from the moment the submission is archived. This date can be changed to an earlier date (Provided by the contributor) but **we won't hold the data for more than 2 years**
 
 Once the dataset is released in an HCA snapshot release, the contributor should be informed and provided with the link to their dataset on the HCA Data Browser.
 
@@ -217,9 +219,9 @@ Note that this is a constantly changing space, this email was last updated 2020-
 > 
 > 3 What’s next?
 > 
-> After we have put together your data and metadata into a valid submission we will archive your data and metadata in [BioStudies](https://www.ebi.ac.uk/biostudies/), [BioSamples](https://www.ebi.ac.uk/biosamples/) and the [European Nucleotide Archive](https://www.ebi.ac.uk/ena/browser/home) and provide you with accessions for your manuscript. We will also ensure your data and metadata make it into the next HCA DCP snapshot releaserelease/snapshot. As indicated by you, we will ensure no data or metadata is made public until [enter date] / we will make the data public as soon as it is submitted.
+> After we have put together your data and metadata into a valid submission we will archive your data and metadata in [BioStudies](https://www.ebi.ac.uk/biostudies/), [BioSamples](https://www.ebi.ac.uk/biosamples/) and the [European Nucleotide Archive](https://www.ebi.ac.uk/ena/browser/home) and provide you with accessions for your manuscript. We will also ensure your data and metadata make it into the next HCA DCP snapshot releaserelease/snapshot. As indicated by you, we will ensure no data or metadata is made public until [enter date, 2 years from now]. / we will make the data public as soon as it is submitted.
 > 
-> If you would also like your study to be brokered to [ArrayExpress](https://www.ebi.ac.uk/arrayexpress/), please let us know. 
+> [IF DATA RELEASE IS NOT IMMEDIATE] Please note that this is a release date that we set up as default to allow for manuscripts to be reviewed and corrections to be made. If you want this data to be released earlier, please contact us when the data can be openly shared and we will release it immediately.
 > 
 > Don’t hesitate to get back in touch if you have any issues with any part of the process.
 > 

--- a/docs/SOPs/dataset_wrangling_SOP.md
+++ b/docs/SOPs/dataset_wrangling_SOP.md
@@ -302,7 +302,7 @@ Where either the expression matrix or cell type annotations cannot be found, the
 
 ### Filling in metadata about the files
 
-For datasets with large number of files, the [ENA filename extractor tool](https://github.com/ebi-ait/hca-ebi-wrangler-central/blob/master/src/ena_filename_extractor.py) can be of use. It requires at least to have already filled the 'INSDC Experiment Accesion' at the 'Cell suspension' and the 'Sequence file' tabs. The wangler has to manually download a JSON report from the corresponding project's page at ENA. This script will fill in the 'File name' column at the 'Sequence file' tab. 
+For datasets with large number of files, the [ENA filename extractor tool](https://github.com/ebi-ait/hca-ebi-wrangler-central/blob/master/src/ena_filename_extractor.py) can be of use. It requires at least to have already filled the 'INSDC Experiment Accesion' at the 'Cell suspension' and the 'Sequence file' tabs. The wrangler has to manually download a JSON report from the corresponding project's page at ENA. This script will fill in the 'File name' column at the 'Sequence file' tab. 
 
 For each expression matrix or cell type annotation file that is found, a row needs to be filled in the metadata spreadsheet, in the ‘Analysis file’ tab. Analysis files can be linked to sequence files or biomaterial entities via processes; This is done in the spreadsheet in the same way that other entities are linked. Information related to the analysis protocol is captured in the Analysis_protocol entity (See the Analysis protocol tab) linked to the process
 

--- a/docs/SOPs/dataset_wrangling_SOP.md
+++ b/docs/SOPs/dataset_wrangling_SOP.md
@@ -302,7 +302,7 @@ Where either the expression matrix or cell type annotations cannot be found, the
 
 ### Filling in metadata about the files
 
-For datasets with large number of files, the [ENA filename extractor tool](https://github.com/ebi-ait/hca-ebi-wrangler-central/blob/master/src/fill_ontologies.py) can be of use. It requires at least to have already filled the 'INSDC Experiment Accesion' at the 'Cell suspension' and the 'Sequence file' tabs. The wangler has to manually download a JSON report from the corresponding project's page at ENA. This script will fill in the 'File name' column at the 'Sequence file' tab. 
+For datasets with large number of files, the [ENA filename extractor tool](https://github.com/ebi-ait/hca-ebi-wrangler-central/blob/master/src/ena_filename_extractor.py) can be of use. It requires at least to have already filled the 'INSDC Experiment Accesion' at the 'Cell suspension' and the 'Sequence file' tabs. The wangler has to manually download a JSON report from the corresponding project's page at ENA. This script will fill in the 'File name' column at the 'Sequence file' tab. 
 
 For each expression matrix or cell type annotation file that is found, a row needs to be filled in the metadata spreadsheet, in the ‘Analysis file’ tab. Analysis files can be linked to sequence files or biomaterial entities via processes; This is done in the spreadsheet in the same way that other entities are linked. Information related to the analysis protocol is captured in the Analysis_protocol entity (See the Analysis protocol tab) linked to the process
 


### PR DESCRIPTION
- `Contributor communications SOP`:
   - Added context for the archiving date to be set 2 years into the future
   - Added optional new paragraph about why the date is set up 2 years into the future and how the contributor can contact us to release early
- `docs/SOPs/dataset_wrangling_SOP.md`:
   - Fixed a hyperlink that was pointing to the wrong script