### PR TITLE
Add hca-publication email template in the SOPs

### DIFF
--- a/docs/SOPs/contributor_communication_SOP.md
+++ b/docs/SOPs/contributor_communication_SOP.md
@@ -150,7 +150,18 @@ These templates are considered a guide to provide a skeleton with the required i
 > [primary wrangler name]
 > 
 > On behalf of the HCA DCP Data Wrangling Team
+#### HCA branded publication - no preprint or publication 
 
+Dear [name/s of contributor/s],
+
+Congratulations on your HCA manuscript! We are looking forward to hearing more about your project, and will add your publication to our project catalogue (https://www.ebi.ac.uk/humancellatlas/project-catalogue/) as a HCA publication once a preprint or publication is available. 
+
+Do you have any time-sensitive requirements on archiving, or have you already archived your data in a specific database?
+
+Warm regards,
+[wrangler name] 
+
+On Behalf of the HCA DCP Ingestion Service
 #### HCA branded publication - first contact
 
 > Dear [name/s of contributor/s],

--- a/docs/SOPs/contributor_communication_SOP.md
+++ b/docs/SOPs/contributor_communication_SOP.md
@@ -43,6 +43,11 @@ The first contact email should contain:
 
 [Template email](#first-contact---data-questionnaire){: .btn .btn-blue }
 
+### Contact after an HCA publication email
+Wrangler team might be CC'ed in an email informing the authors that a publication has been accepted as an HCA publication (subject __HCA Branded Publication__). In this case, we can contact them and do not wait for them to reach. 
+
+[Template email](#hca-branded-publication---first-contact){: .btn .btn-blue }
+
 ## Follow-up contact
 Once the primary wrangler has gained more information about the dataset, a custom spreadsheet can be generated with the relevant tabs and fields for the contributor’s experiment. 
 
@@ -145,6 +150,23 @@ These templates are considered a guide to provide a skeleton with the required i
 > [primary wrangler name]
 > 
 > On behalf of the HCA DCP Data Wrangling Team
+
+#### HCA branded publication - first contact
+
+> Dear [name/s of contributor/s],
+> 
+> Congratulations on your HCA manuscript!
+> We have added the information about your publication to our project catalogue (https://www.ebi.ac.uk/humancellatlas/project-catalogue/) as a HCA publication.
+> Due to internal processes it will take a day to display the publication information, in the meantime any feedback about the HCA project catalogue is greatly appreciated!
+> 
+> Do you have any time-sensitive requirements on archiving, or have you already archived your data in a specific database?
+> 
+> Warm regards,
+> [wrangler name]
+> 
+> On Behalf of the HCA DCP Ingestion Service
+
+
 
 ### Terms and Conditions
 


### PR DESCRIPTION
Added small description on when we should use it, and the template at the end of the file.