### PR TITLE
Improve ontology script

### DIFF
--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -239,8 +239,12 @@ def select_term(ontologies_dict, term, key, schema_info, zooma, known_iri={}, mu
         elif answer.lower() == 'exit' or answer.lower() == "q":
             raise KeyboardInterrupt
         else:
-            dict_index_key = list(ontologies_dict.keys())[int(answer)-1]
-            return ontologies_dict[dict_index_key], known_iri
+            try:
+                dict_index_key = list(ontologies_dict.keys())[int(answer)-1]
+                return ontologies_dict[dict_index_key], known_iri
+            except:
+                print("Invalid answer: {} \nNew attempt".format(answer))
+                return select_term(ontologies_dict, term, key, schema_info, zooma, known_iri)
 
 
 def save_workbook(path, workbook, suffix="_ontologies"):

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -190,8 +190,7 @@ def select_term(ontologies_dict, term, key, schema_info, zooma, known_iri={}, mu
         return ontologies_dict[first_key], known_iri
     # If there is an exact string match, use it - unless it's from HP --> MONDO terms have priority even if they are not an exact string match
     elif ontologies_dict and ontologies_dict[first_key]["label"].lower() == term.lower() and \
-            not ontologies_dict[first_key]["ontology_prefix"]=="HP" and \
-            ontologies_dict[first_key]["is_defining_ontology"]==True and not zooma:
+            not ontologies_dict[first_key]["obo_id"][0:2]=="HP" and not zooma:
         print("Found exact match for term {} (Ontology: {})".format(term, ontologies_dict[first_key]["obo_id"]))
         return ontologies_dict[first_key], known_iri
     else:
@@ -300,7 +299,6 @@ def parse_wb(file_path, wb, schema, zooma, keep):
                         if ontologies_dict:  # Select term from found ontologies
                             ontology, known_iri = select_term(ontologies_dict, cell.value, programmatic_key,
                                                               schema_info, zooma, known_iri)
-                            # todo: change select_term to evaluate multi fields and compare w/known_terms and known_ontologies
                             known_terms.append(cell.value)
                             if isinstance(ontology, list):  # If multi ontology returned, concatenate values
                                 ontologies = {}

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -48,6 +48,9 @@ Instructions of use and main algorithm
         - Input 'm': You'll be prompted to introduce the term that you want to look for
         - Input 'none': The ontology cells will be filled with empty strings
     - No ontology was found for this term. Please input it manually: Input the term that you want to search.
+
+    If new ontology branches have been added to the ontology modules take care to delete the pickled schemas so that
+    the script can load the updated schemas instead
 """
 
 import os
@@ -295,6 +298,7 @@ def parse_wb(file_path, wb, schema, zooma, keep):
                         if ontologies_dict:  # Select term from found ontologies
                             ontology, known_iri = select_term(ontologies_dict, cell.value, programmatic_key,
                                                               schema_info, zooma, known_iri)
+                            # todo: change select_term to evaluate multi fields and compare w/known_terms and known_ontologies
                             known_terms.append(cell.value)
                             if isinstance(ontology, list):  # If multi ontology returned, concatenate values
                                 ontologies = {}

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -190,7 +190,8 @@ def select_term(ontologies_dict, term, key, schema_info, zooma, known_iri={}, mu
         return ontologies_dict[first_key], known_iri
     # If there is an exact string match, use it - unless it's from HP --> MONDO terms have priority even if they are not an exact string match
     elif ontologies_dict and ontologies_dict[first_key]["label"].lower() == term.lower() and \
-            not ontologies_dict[first_key]["ontology_prefix"]=="HP" and not zooma:
+            not ontologies_dict[first_key]["ontology_prefix"]=="HP" and \
+            ontologies_dict[first_key]["is_defining_ontology"]==True and not zooma:
         print("Found exact match for term {} (Ontology: {})".format(term, ontologies_dict[first_key]["obo_id"]))
         return ontologies_dict[first_key], known_iri
     else:

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -188,8 +188,9 @@ def select_term(ontologies_dict, term, key, schema_info, zooma, known_iri={}, mu
             ontologies_dict[first_key]["source"] == "HCA":
         print("Found high confidence, HCA match for term {} (Ontology: {})".format(term, ontologies_dict[first_key]["obo_id"]))
         return ontologies_dict[first_key], known_iri
-    # If there is an exact string match, use it
-    elif ontologies_dict and ontologies_dict[first_key]["label"].lower() == term.lower() and not zooma:
+    # If there is an exact string match, use it - unless it's from HP --> MONDO terms have priority even if they are not an exact string match
+    elif ontologies_dict and ontologies_dict[first_key]["label"].lower() == term.lower() and \
+            not ontologies_dict[first_key]["ontology_prefix"]=="HP" and not zooma:
         print("Found exact match for term {} (Ontology: {})".format(term, ontologies_dict[first_key]["obo_id"]))
         return ontologies_dict[first_key], known_iri
     else:


### PR DESCRIPTION
This PR adresses two things:
1. for disease: disallow exact text match by default for HP terms
2. fixes keyboard input bug - when the input for the ontology selection doesn't match the allowed options the menu and choice is presented again so the script doesn't crush without saving progress

There is one more thing I'd like to fix but I don't know how.
If the HCAO/OLS query in search_child_term() doesn't have any results the function returns None instead of a dictionary with ontology terms. When the dictionary is used the program crashes without saving progress because it doesn't make it back to parse_wb() 
I would like the error to be handled in a way that allows the program to save the progress made so far before closing with the error message about empty query