### PR TITLE
Fix error for file type content

### DIFF
--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -145,7 +145,9 @@ def search_child_term(term, schema_info, iri={}):
     else:
         if "none" in term.lower():
             return {"none": {"obo_id": "", "label": ""}}, iri
-        return None, iri
+        term = input("No ontologies were found for the term (Cell value = {}). Please input it manually: "
+                     .format(term))
+        return search_child_term(term, schema_info)
     ontology_dict = {ontology['obo_id']: ontology for ontology in ontology_response}
     return ontology_dict, iri
 

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -144,7 +144,7 @@ def search_child_term(term, schema_info, iri={}):
         ontology_response.extend(response["response"]["docs"])
     else:
         if "none" in term.lower():
-            return [{"obo_id": "", "label": ""}], iri
+            return {"none": {"obo_id": "", "label": ""}}, iri
         return None, iri
     ontology_dict = {ontology['obo_id']: ontology for ontology in ontology_response}
     return ontology_dict, iri

--- a/src/fill_ontologies.py
+++ b/src/fill_ontologies.py
@@ -80,7 +80,7 @@ def get_iri(classes, iri={}):
     for ontology_class in classes:
         ontology_name = ontology_class.split(":")[0]
         if ontology_name not in iri:
-            request = rq.get("https://www.ebi.ac.uk/ols/api/terms?id={}".format(ontology_class))
+            request = rq.get("https://ontology.archive.data.humancellatlas.org/api/terms?id={}".format(ontology_class))
             response = request.json()
             iri[ontology_name] = "/".join(response["_embedded"]["terms"][0]["iri"].split("/")[:-1])
     return iri
@@ -127,11 +127,10 @@ def get_schema_info(key, json_schemas):
 def search_child_term(term, schema_info, iri={}):
     # Search OLS for ontologies based on string matching in ontologies determined by schema graph restriction
     ontology_response = []
-    request_query = "https://ontology.archive.data.humancellatlas.org/api/search?q=" if "hcao" in schema_info['ontologies'] else \
-                    "http://www.ebi.ac.uk/ols/api/search?q="
+    request_query = "https://ontology.archive.data.humancellatlas.org/api/search?q="
     if schema_info['include_self']:
         for ontology_class in schema_info['classes']:
-            request = rq.get("http://www.ebi.ac.uk/ols/api/terms?id={}".format(ontology_class))
+            request = rq.get("https://ontology.archive.data.humancellatlas.org/api/terms?id={}".format(ontology_class))
             response = request.json()
             if response["_embedded"]["terms"][0]["label"] == term:
                 return {response["_embedded"]["terms"][0]["obo_id"]: response["_embedded"]["terms"][0]}, iri


### PR DESCRIPTION
### Context
The edam ontology in ols has recently changed the prefix for the onotlogy ids
ex: 
Count matrix
HCAO --> [data:3917](https://ontology.archive.data.humancellatlas.org/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fdata_3917)
OLS --> [EDAM:3917](https://www.ebi.ac.uk/ols4/ontologies/edam/classes/http%253A%252F%252Fedamontology.org%252Fdata_3917)

**Consequence**
This has two consequences: 
1. the ontology restrictions from the schema can't be applied because the ontologies id have no match in OLS --> code breaks
2. if the terms are found the ontology IDs from OLS have the new format `EDAM:` so they won't validate in ingest

### Solution
I don't know if this change in prefix is premanent but it is breaking the script, so rather than querying OLS for the ontolgy terms I've made some changes to query HCAO instead
I've also added a few lines to make sure that if no ontlogy term is found we can provide a new term to search for 

