### PR TITLE
Add managed access SOPs

### DIFF
--- a/docs/SOPs/Advanced_other/Advanced_other.md
+++ b/docs/SOPs/Advanced_other/Advanced_other.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Advanced & other SOPs
-nav_order: 9
+nav_order: 10
 parent: SOPs
 has_children: true
 ---

--- a/docs/SOPs/After_export/After_export.md
+++ b/docs/SOPs/After_export/After_export.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: After export
-nav_order: 6
+nav_order: 7
 parent: SOPs
 has_children: true
 ---

--- a/docs/SOPs/Managed_access/Data_Contributor_Agreement_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Contributor_Agreement_SOP.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Data Contributor Agreement SOP
+parent: Managed access
+grand_parent: SOPs
+nav_order: 2
+last_modified_date: 30/05/2024
+---
+
+<script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
+
+# Data Contributor Agreement SOP
+
+This document explains how a wrangler registers a managed access project and helps fill out the data contributor agreement (DCA). See [here](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Contributor_Agreement_explained.html) if you are unfamiliar with the DCA.
+
+## Create a project in HCA Data Repository Ingest Service 
+This step begins once the wranglers receive a submission request in the form of an email from the contributor. The contributor needs to provide the name and email address for the DCA signers.
+
+1. Register a new project in ingest with minimal details. The only metadata needed is:
+   1. Primary contact/data contributor information 
+   2. Project title. If a title has been provided make sure there is no identifiable information in the project title. If no title was provided use the contributor name and amend with the title provided in the DCA once it’s signed.
+   3. Data use restriction. Fill in the data_use_restriction as GRU-NCU, as the stricter of the Managed access options. 
+   4. Make sure the project is not displayed on the catalogue.
+2. Save the project to generate a project UUID. 
+3. Forward the singer’s contact information to the HCA executive office so they can start the signing process
+4. Let the contributors know that their details have been forwarded to the executive office and they will receive an email to sign the DCA shortly
+
+## Fill in the DCA agreement
+The designated wrangler receives an email to sign the DCA on DocuSign. No account is required for this.
+1. Enter the project UUID from the step above
+2. Sign as a Data Wrangler
+
+## Complete DCA agreement
+Once all parties have signed the DCA agreement, the data wrangler will receive a copy of the signed agreement.
+1. Update the project title and data_use_restriction to reflect the DCA
+
+We do not need to keep a signed copy of the DCA, the HCA executive office is keeping records for that.
+For next steps of the Managed access submission process see [Managed access dataset - Pre-submission](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Pre-submission_SOP.html)
+

--- a/docs/SOPs/Managed_access/Data_Contributor_Agreement_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Contributor_Agreement_SOP.md
@@ -4,25 +4,25 @@ title: Data Contributor Agreement SOP
 parent: Managed access
 grand_parent: SOPs
 nav_order: 2
-last_modified_date: 30/05/2024
+last_modified_date: 04/06/2024
 ---
 
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
 # Data Contributor Agreement SOP
 
-This document explains how a wrangler registers a managed access project and helps fill out the data contributor agreement (DCA). See [here](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Contributor_Agreement_explained.html) if you are unfamiliar with the DCA.
+This document explains how a wrangler registers a managed access project in HCA Data Repository Ingest Service and helps fill out the data contributor agreement (DCA). See [Data Contributor Agreement explained](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Contributor_Agreement_explained.html) if you are unfamiliar with the DCA.
 
 ## Create a project in HCA Data Repository Ingest Service 
 This step begins once the wranglers receive a submission request in the form of an email from the contributor. The contributor needs to provide the name and email address for the DCA signers.
 
-1. Register a new project in ingest with minimal details. The only metadata needed is:
+1. Register a new project in HCA Data Repository Ingest Service with minimal details. The only metadata needed is:
    1. Primary contact/data contributor information 
    2. Project title. If a title has been provided make sure there is no identifiable information in the project title. If no title was provided use the contributor name and amend with the title provided in the DCA once it’s signed.
    3. Data use restriction. Fill in the data_use_restriction as GRU-NCU, as the stricter of the Managed access options. 
    4. Make sure the project is not displayed on the catalogue.
 2. Save the project to generate a project UUID. 
-3. Forward the singer’s contact information to the HCA executive office so they can start the signing process
+3. Forward the signing parties' (PI and institutional legal representative) contact information to the HCA executive office so they can start the DCA signing process
 4. Let the contributors know that their details have been forwarded to the executive office and they will receive an email to sign the DCA shortly
 
 ## Fill in the DCA agreement
@@ -32,8 +32,8 @@ The designated wrangler receives an email to sign the DCA on DocuSign. No accoun
 
 ## Complete DCA agreement
 Once all parties have signed the DCA agreement, the data wrangler will receive a copy of the signed agreement.
-1. Update the project title and data_use_restriction to reflect the DCA
+1. Update the project title and data_use_restriction in HCA Data Repository Ingest Service to reflect the DCA
 
 We do not need to keep a signed copy of the DCA, the HCA executive office is keeping records for that.
-For next steps of the Managed access submission process see [Managed access dataset - Pre-submission](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Pre-submission_SOP.html)
+For next steps of the Managed access submission process see [Managed access project - Pre-submission](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Pre-submission_SOP.html)
 

--- a/docs/SOPs/Managed_access/Data_Contributor_Agreement_explained.md
+++ b/docs/SOPs/Managed_access/Data_Contributor_Agreement_explained.md
@@ -4,7 +4,7 @@ title: Data Contributor Agreement explained
 parent: Managed access
 grand_parent: SOPs
 nav_order: 1
-last_modified_date: 30/05/2024
+last_modified_date: 04/06/2024
 ---
 
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
@@ -17,7 +17,7 @@ The reuse conditions are:
 - GRU: General Research Use - for Managed access
 - GRU-NCU: General Research Use, Non-Commercial use - for Managed access, non-commercial use only
 
-To start signing the DCA through [DocuSign](https://www.docusign.com/en-gb#drd) the contributors need to indicate:
+To start signing the DCA through [DocuSign](https://www.docusign.com/en-gb#drd) the contributors need to provide:
 - The name and email address of the institutional representative who will sign the DCA on behalf of the data contributor organisation. This person must be authorised to sign legal agreements for their institution.
 - The name and email address of the person who will sign the DCA as Principal Investigator. This person is required to ensure all data accepted into the HCA has the requisite protection measures, therefore adhering to local data protection laws and regulations.
 

--- a/docs/SOPs/Managed_access/Data_Contributor_Agreement_explained.md
+++ b/docs/SOPs/Managed_access/Data_Contributor_Agreement_explained.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: Data Contributor Agreement explained
+parent: Managed access
+grand_parent: SOPs
+nav_order: 1
+last_modified_date: 30/05/2024
+---
+
+<script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
+
+# Data Contributor Agreement explained
+The Data Contributor Agreement (DCA) is a legal agreement between the data contributor and HCA Inc, where the contributor authorises HCA to publish their data on the Data Portal with appropriate reuse conditions. 
+
+The reuse conditions are:
+- NRES: Non-Restricted Use - for Open access
+- GRU: General Research Use - for Managed access
+- GRU-NCU: General Research Use, Non-Commercial use - for Managed access, non-commercial use only
+
+To start signing the DCA through [DocuSign](https://www.docusign.com/en-gb#drd) the contributors need to indicate:
+- The name and email address of the institutional representative who will sign the DCA on behalf of the data contributor organisation. This person must be authorised to sign legal agreements for their institution.
+- The name and email address of the person who will sign the DCA as Principal Investigator. This person is required to ensure all data accepted into the HCA has the requisite protection measures, therefore adhering to local data protection laws and regulations.
+
+HCA data wranglers are the first party to fill in the DCA and are responsible for providing a project uuid.
+
+At the moment the DocuSign process is owned by the HCA executive office, but we are in the process of setting up a wrangler account for DocuSign so that a designated HCA data wrangler can start the signing process.

--- a/docs/SOPs/Managed_access/Data_Transfer_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Transfer_SOP.md
@@ -4,12 +4,12 @@ title: Data Transfer SOP
 parent: Managed access
 grand_parent: SOPs
 nav_order: 4
-last_modified_date: 30/05/2024
+last_modified_date: 04/06/2024
 ---
 
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
-# Managed access dataset - Data Transfer SOP
+# Managed access project - Data Transfer SOP
 Once the data contributor has notified the HCA data wrangler that they have completed the  metadata spreadsheet, the wrangler can give them access to hca-util area
 
 ## Data and metadata upload prerequisites
@@ -29,7 +29,7 @@ Once the contributors have notified the wrangler that the upload is complete:
 1. Check the contents of the hca-util area - make sure the spreadsheet is there
 2. Confirm with the contributor the name of the metadata spreadsheet and the number of files uploaded
 
-If the hca-util area contains the expected files proceed to the [Managed access dataset - Data and metadata review and export SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Review_and_export_SOP.html)
+If the hca-util area contains the expected files proceed to the [Managed access project - Data and metadata review and export SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Review_and_export_SOP.html)
 )
 
 

--- a/docs/SOPs/Managed_access/Data_Transfer_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Transfer_SOP.md
@@ -10,23 +10,23 @@ last_modified_date: 04/06/2024
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
 # Managed access project - Data Transfer SOP
-Once the data contributor has notified the HCA data wrangler that they have completed the  metadata spreadsheet, the wrangler can give them access to hca-util area
+Once the data contributor has notified the HCA data wrangler that they have completed the  metadata spreadsheet, the wrangler can give them access to the secure storage area
 
 ## Data and metadata upload prerequisites
-To upload data to hca-util contributors need credentials and their project’s area uuid. Credentials for hca-util must be zipped and password protected. 
-1. Send an email addressed just to the contributor containing the area’s uuid and instructions on how to upload files to hca-util*
-2. Send an email addressed just to the contributor containing the zipped credentials**
-3. Send an email addressed just to the contributor containing the password for the*** credentials
+To upload data to the AWS secure storage area using the hca-util tool contributors need credentials and their project’s area uuid. Credentials for hca-util tool must be zipped and password protected. 
+1. Send an email addressed only to the contributor containing the area’s uuid and instructions on how to upload files using the hca-util tool
+2. Send an email addressed only to the contributor containing the zipped credentials
+3. Send an email addressed only to the contributor containing the password for the zipped credentials
 
 [Template emails](#Email-templates){: .btn .btn-blue }
 
 ## Data and Metadata Upload
-1. Send the contributor [these instructions](https://github.com/ebi-ait/hca-documentation/wiki/How-to-upload-data-to-an-upload-area-using-hca-util), explaining how to securely transfer their data to their assigned private upload area, using the template below. 
+1. Send the contributor [these instructions](https://github.com/ebi-ait/hca-documentation/wiki/How-to-upload-data-to-an-upload-area-using-hca-util), explaining how to securely transfer their data to their assigned secure storage area, using the template below. 
 2. Ask the contributor to email the helpdesk advising when they have successfully uploaded data and metadata to their secure area
 
 ## Verify Upload
 Once the contributors have notified the wrangler that the upload is complete:
-1. Check the contents of the hca-util area - make sure the spreadsheet is there
+1. Check the contents of the secure storage area - make sure the spreadsheet is there
 2. Confirm with the contributor the name of the metadata spreadsheet and the number of files uploaded
 
 If the hca-util area contains the expected files proceed to the [Managed access project - Data and metadata review and export SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Review_and_export_SOP.html)
@@ -37,7 +37,7 @@ If the hca-util area contains the expected files proceed to the [Managed access 
 >Dear < Contributor Name >
 >
 >The upload area UUID for your project is: <uuid>
->To upload files to the cloud area please refer to this guide. You should receive the credentials needed to access the secure area soon, if you have any issues please let me know.
+>To upload files to the secure AWS storage area please refer to [this guide](https://github.com/ebi-ait/hca-documentation/wiki/How-to-upload-data-to-an-upload-area-using-hca-util). You should receive the credentials needed to access the area soon, if you have any issues please let me know.
 >Please let me know when you’ve completed the upload of data and metadata so that we can proceed with the submission.
 >
 >Best regards

--- a/docs/SOPs/Managed_access/Data_Transfer_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Transfer_SOP.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Data Transfer SOP
+parent: Managed access
+grand_parent: SOPs
+nav_order: 4
+last_modified_date: 30/05/2024
+---
+
+<script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
+
+# Managed access dataset - Data Transfer SOP
+Once the data contributor has notified the HCA data wrangler that they have completed the  metadata spreadsheet, the wrangler can give them access to hca-util area
+
+## Data and metadata upload prerequisites
+To upload data to hca-util contributors need credentials and their project’s area uuid. Credentials for hca-util must be zipped and password protected. 
+1. Send an email addressed just to the contributor containing the area’s uuid and instructions on how to upload files to hca-util*
+2. Send an email addressed just to the contributor containing the zipped credentials**
+3. Send an email addressed just to the contributor containing the password for the*** credentials
+
+[Template emails](#Email-templates){: .btn .btn-blue }
+
+## Data and Metadata Upload
+1. Send the contributor [these instructions](https://github.com/ebi-ait/hca-documentation/wiki/How-to-upload-data-to-an-upload-area-using-hca-util), explaining how to securely transfer their data to their assigned private upload area, using the template below. 
+2. Ask the contributor to email the helpdesk advising when they have successfully uploaded data and metadata to their secure area
+
+## Verify Upload
+Once the contributors have notified the wrangler that the upload is complete:
+1. Check the contents of the hca-util area - make sure the spreadsheet is there
+2. Confirm with the contributor the name of the metadata spreadsheet and the number of files uploaded
+
+If the hca-util area contains the expected files proceed to the [Managed access dataset - Data and metadata review and export SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Review_and_export_SOP.html)
+)
+
+
+### Email templates
+>Dear < Contributor Name >
+>
+>The upload area UUID for your project is: <uuid>
+>To upload files to the cloud area please refer to this guide. You should receive the credentials needed to access the secure area soon, if you have any issues please let me know.
+>Please let me know when you’ve completed the upload of data and metadata so that we can proceed with the submission.
+>
+>Best regards
+>< Your Name >
+
+>Dear < Contributor Name >
+>
+>Attached at the end of the email you will find a zip file with the credentials you need for the hca-util tool to upload your data. I will send you a separate email for the password of the zip file.
+>Please treat these credentials securely and do not share them with anyone. 
+>
+>Best regards
+>< Your Name >
+
+
+>Dear < Contributor Name >
+>
+>The password to open the credentials zip file is: < password >
+>
+>Best Regards
+>< Your Name >

--- a/docs/SOPs/Managed_access/Data_Transfer_SOP.md
+++ b/docs/SOPs/Managed_access/Data_Transfer_SOP.md
@@ -36,7 +36,7 @@ If the hca-util area contains the expected files proceed to the [Managed access 
 ### Email templates
 >Dear < Contributor Name >
 >
->The upload area UUID for your project is: <uuid>
+>The identifier for your project is: <uuid>
 >To upload files to the secure AWS storage area please refer to [this guide](https://github.com/ebi-ait/hca-documentation/wiki/How-to-upload-data-to-an-upload-area-using-hca-util). You should receive the credentials needed to access the area soon, if you have any issues please let me know.
 >Please let me know when you’ve completed the upload of data and metadata so that we can proceed with the submission.
 >

--- a/docs/SOPs/Managed_access/Managed_access.md
+++ b/docs/SOPs/Managed_access/Managed_access.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Managed access
+nav_order: 5
+parent: SOPs
+has_children: true
+last_modified_date: 4/06/2024
+---
+# Managed access
+
+This collection of SOPs describes how managed access dataset have to be handled.
+If you are updating any of the SOPs please update the version and publishing date.
+
+Current version: 1 \
+Publishing date: 4/6/2024
+
+

--- a/docs/SOPs/Managed_access/Pre-submission_SOP.md
+++ b/docs/SOPs/Managed_access/Pre-submission_SOP.md
@@ -32,10 +32,10 @@ Send to the contributor, with the wrangler email in CC
 
 
 ## Prepare a secure storage area
-Prepare a secure storage area for the projects’ data and metadata. 
+Prepare a secure storage area in AWS for the projects’ data and metadata. 
 1. Create a storage area using the project's uuid as name \
 `$ hca-util create <uuid-of-project>` 
-2. The contributor needs a set of credentials to be able to upload data to the hca-util area. 
+2. The contributor needs a set of credentials (AWS access key and AWS secret key) to be able to upload data to the AWS secure storage area.
 Ask a developer to follow [these instructions](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Introduction/dataset_wrangling_SOP.html#aws-user-for-contributors) to create the credentials. The only information needed is the contributor’s name and email address. 
 
 
@@ -53,7 +53,7 @@ For next steps see [Managed access project - Data Transfer SOP](https://ebi-ait.
 >
 > If you’ve used organoid or cell line samples or you’ve performed spatial transcriptomics experiments please let me know so I can send you additional information. It’s possible to customise the spreadsheet to better fit your experiment design, so please get in touch if this is something I can help with.
 > 2. Upload your data and metadata to our secure cloud space
-> I am preparing a secure area specific for your data submission where you can upload your data files and the filled-in spreadsheet. Please let me know once you are happy you have filled out the spreadsheet and are ready to upload your data and metadata files, and I'll send you the details of this upload area and instructions on next steps.
+> I am preparing a secure storage area specific for your project where you can upload your data files and the filled-in spreadsheet. Please let me know once you are happy you have filled out the spreadsheet and are ready to upload your data and metadata files, and I'll send you the details of this upload area and instructions on next steps.
 > 
 >**In order to avoid circulating any potentially sensitive data over unencrypted channels, please refrain from sending any data or metadata via email.** This includes filled-in or partially completed copies of the spreadsheet. 
 > 3. Review and Export

--- a/docs/SOPs/Managed_access/Pre-submission_SOP.md
+++ b/docs/SOPs/Managed_access/Pre-submission_SOP.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: Pre-submission SOP
+parent: Managed access
+grand_parent: SOPs
+nav_order: 3
+last_modified_date: 30/05/2024
+---
+
+<script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
+
+# Managed access dataset - Pre-submission SOP
+Refer to this guide to prepare for the ingestion of a managed access dataset once the DCA has been signed.
+
+## Register the project in DUOS system
+
+A copy of the managed access project will have to be created in [DUOS](https://duos.org/) to control access to the dataset once it’s available on the Data Portal.
+
+1. Email Jonathan at jlawson@broadinstitute.org with the [DUOS project information fields](https://docs.google.com/document/d/18pzeKafFQZ0rhqrb2DLOCciHUu4On4g2rtgnqygIfTE/edit#heading=h.674bm0dao5mr), using the information from the DCA agreement. This is mainly information about the dataset, the only personal data shared with the Broad is the PI’s name.
+2. Register in ingest the project’s DUOS id provided by Jonathan
+
+## Send instructions to contributor
+Send an email to the data contributor with instructions on next steps*
+
+Send to the contributor, with the wrangler email in CC
+1. An outline of next steps
+2. The metadata spreadsheet guide
+3. A metadata spreadsheet template
+4. A reminder to not share any sensitive data or metadata via email or other means of communication. 
+
+[Template email](#Email-template--Instructions-for-the-contributor){: .btn .btn-blue }
+
+
+## Prepare a secure storage area
+Prepare a secure storage area for the projects’ data and metadata. 
+1. Create a storage area using the project's uuid as name \
+`$ hca-util create <uuid-of-project>` 
+2. The contributor needs a set of credentials to be able to upload data to the hca-util area. 
+Ask a developer to follow [these instructions](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Introduction/dataset_wrangling_SOP.html#aws-user-for-contributors) to create the credentials. The only information needed is the contributor’s name and email address. 
+
+
+
+For next steps see [Managed access dataset - Data Transfer SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Transfer_SOP.html)
+
+### Email template - Instructions for the contributor
+
+> Dear [name/s of contributor/s],
+>
+> Thank you for signing the Data Contributor Agreement.
+> The next steps are:
+> 1. Assemble your metadata to meet the HCA standard
+> Attached to this email you will find a metadata spreadsheet where you can fill in all the details of your experimental metadata. A guide to help in this process can be found here: [Spreadsheet Quick Guide](https://ebi-ait.github.io/hca-metadata-community/contributing/spreadsheet-guide.html)
+>
+> If you’ve used organoid or cell line samples or you’ve performed spatial transcriptomics experiments please let me know so I can send you additional information. It’s possible to customise the spreadsheet to better fit your experiment design, so please get in touch if this is something I can help with.
+> 2. Upload your data and metadata to our secure cloud space
+> I am preparing a secure area specific for your data submission where you can upload your data files and the filled-in spreadsheet. Please let me know once you are happy you have filled out the spreadsheet and are ready to upload your data and metadata files, and I'll send you the details of this upload area and instructions on next steps.
+> 
+>**In order to avoid circulating any potentially sensitive data over unencrypted channels, please refrain from sending any data or metadata via email.** This includes filled-in or partially completed copies of the spreadsheet. 
+> 3. Review and Export
+> The HCA data wrangling team will take care of reviewing and validating the data and metadata once you upload it. If anything needs to be adjusted, I’ll update you in due course. In general we aim to complete the review in 7 business days.
+> 4. Publish the project
+>Once everything is reviewed and ready, I’ll update you with a possible release date so you can confirm if you’re ready to proceed with publishing the dataset under managed access.
+>
+> Do not hesitate to get back in touch if you have any issues with any part of the process. I would also like to suggest a Zoom call to walk you through the metadata spreadsheet once you have taken an initial look at it. Please let me know what times might be suitable for you.
+>
+> Warm regards,
+> [primary wrangler name]
+> 
+> On behalf of the HCA Data Platform - Data Wrangling Team
+

--- a/docs/SOPs/Managed_access/Pre-submission_SOP.md
+++ b/docs/SOPs/Managed_access/Pre-submission_SOP.md
@@ -4,20 +4,20 @@ title: Pre-submission SOP
 parent: Managed access
 grand_parent: SOPs
 nav_order: 3
-last_modified_date: 30/05/2024
+last_modified_date: 04/06/2024
 ---
 
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
-# Managed access dataset - Pre-submission SOP
-Refer to this guide to prepare for the ingestion of a managed access dataset once the DCA has been signed.
+# Managed access project - Pre-submission SOP
+Refer to this guide to prepare for the ingestion of a managed access project once the DCA has been signed.
 
 ## Register the project in DUOS system
 
-A copy of the managed access project will have to be created in [DUOS](https://duos.org/) to control access to the dataset once it’s available on the Data Portal.
+A copy of the managed access project will have to be created in [DUOS](https://duos.org/) to control access to the data once it’s available on the HCA Data Portal.
 
-1. Email Jonathan at jlawson@broadinstitute.org with the [DUOS project information fields](https://docs.google.com/document/d/18pzeKafFQZ0rhqrb2DLOCciHUu4On4g2rtgnqygIfTE/edit#heading=h.674bm0dao5mr), using the information from the DCA agreement. This is mainly information about the dataset, the only personal data shared with the Broad is the PI’s name.
-2. Register in ingest the project’s DUOS id provided by Jonathan
+1. Email the DUOS representative (Jonathan at jlawson@broadinstitute.org) with the [DUOS project information fields](https://docs.google.com/document/d/18pzeKafFQZ0rhqrb2DLOCciHUu4On4g2rtgnqygIfTE/edit#heading=h.674bm0dao5mr), using the information from the DCA agreement. This is mainly project metadata, the only personal data shared with the Broad is the PI’s name.
+2. Register in the HCA Data Repository Ingest Service the project’s DUOS id provided by the DUOS representative
 
 ## Send instructions to contributor
 Send an email to the data contributor with instructions on next steps*
@@ -40,7 +40,7 @@ Ask a developer to follow [these instructions](https://ebi-ait.github.io/hca-ebi
 
 
 
-For next steps see [Managed access dataset - Data Transfer SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Transfer_SOP.html)
+For next steps see [Managed access project - Data Transfer SOP](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/Managed_access/Data_Transfer_SOP.html)
 
 ### Email template - Instructions for the contributor
 
@@ -59,7 +59,7 @@ For next steps see [Managed access dataset - Data Transfer SOP](https://ebi-ait.
 > 3. Review and Export
 > The HCA data wrangling team will take care of reviewing and validating the data and metadata once you upload it. If anything needs to be adjusted, I’ll update you in due course. In general we aim to complete the review in 7 business days.
 > 4. Publish the project
->Once everything is reviewed and ready, I’ll update you with a possible release date so you can confirm if you’re ready to proceed with publishing the dataset under managed access.
+>Once everything is reviewed and ready, I’ll update you with a possible release date so you can confirm if you’re ready to proceed with publishing the project under managed access.
 >
 > Do not hesitate to get back in touch if you have any issues with any part of the process. I would also like to suggest a Zoom call to walk you through the metadata spreadsheet once you have taken an initial look at it. Please let me know what times might be suitable for you.
 >

--- a/docs/SOPs/Managed_access/Review_and_export_SOP.md
+++ b/docs/SOPs/Managed_access/Review_and_export_SOP.md
@@ -10,22 +10,22 @@ last_modified_date: 04/06/2024
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
 # Managed access project - Data and metadata review and export SOP
-Once the the wrangler has verified that the data and metadata files were transferred correctly to the hca-util are they can  proceed with submission creation and validation
+Once the wrangler has verified that the data and metadata files were transferred correctly to the secure storage area using hca-util are they can proceed with project submission creation and validation
 
 ## Submission review and validation
 Data and metadata in a managed access submission are considered sensitive information and must be kept encrypted. Unlike in the case of open access projects, review for a managed access project must be done without ever downloading the metadata spreadsheet - or the data - to a non-encrypted location, like a laptop.
-1. Once the metadata spreadsheet is uploaded to the hca-util area a lambda function will automatically trigger the upload of the spreadsheet to the project in ingest.
-2. If the upload fails because ingest cannot process the spreadsheet, get in touch with the contributor to review their submission in a call. The contributor should share their screen and walk through the spreadsheet.
-3. Review the submission for metadata errors and communicate with the contributor to fix them. Ask the contributor to upload the improved spreadsheet to the hca-util area and repeat from step 1. 
-4. Sync data files directly from hca-util to ingest staging bucket \
+1. Once the metadata spreadsheet is uploaded to the secure AWS storage area a lambda function will automatically trigger the upload of the spreadsheet to the respective project in the HCA Data Repository Ingest Service.
+2. If the spreadsheet upload fails because HCA Data Repository Ingest Service cannot process the spreadsheet, the wrangler will get notified of the problem. Get in touch with the contributor and suggest to review their spreadsheet over a video call. The contributor should share their screen and walk through the spreadsheet.
+3. If the spreadsheet imports successfully in HCA Data Repository Ingest Service, review the submission for metadata errors and communicate with the contributor on how to fix them. Ask the contributor to upload the corrected spreadsheet to the secure storage area and repeat the activities from step 1 onwards. 
+4. Sync the data files directly from the secure storage area provided to the contributor to the HCA Data Repository Ingest Service AWS staging area \
 `$ hca-util sync s3://org-hca-data-archive-upload-prod/<submission-uuid>`
-5. Add ontology terms were necessary, for example for methods, species and developmental stage.
-6. Validate experimental design with the graph validation step. If there are any errors communicate with the contributor so that they can amend the metadata spreadsheet and upload the improved version to the hca-util area
+5. Within HCA Data Repository Ingest Service, add ontology terms where necessary, for example for methods, species and developmental stage.
+6. Validate the experimental design with the graph validation step. If there are any errors, communicate with the contributor so that they can amend the metadata spreadsheet and upload the corrected spreadsheet to the secure storage area and repeat the activities from step 1 onwards.
 
 ## Confirm Project data release
 
-Once the Validation for the Project submission is complete:
-1. Notify the data contributor that the data submission is complete
+Once the Validation for the Project data submission is complete:
+1. Notify the data contributor that the Project data submission is complete
 2. Confirm that they’re happy to proceed to publishing the Project under Managed access
 3. If the contributor wishes to hold the Project private for a period of time, confirm the desired release date and put a reminder in the calendar for that date
 4. If the Project is to be published with the first available release, give an estimate of when they can expect to see the project live on the HCA Data Portal.

--- a/docs/SOPs/Managed_access/Review_and_export_SOP.md
+++ b/docs/SOPs/Managed_access/Review_and_export_SOP.md
@@ -1,0 +1,43 @@
+---
+layout: default
+title: Data and metadata review and export SOP
+parent: Managed access
+grand_parent: SOPs
+nav_order: 5
+last_modified_date: 30/05/2024
+---
+
+<script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
+
+# Managed access dataset - Data and metadata review and export SOP
+Once the the wrangler has verified that the data and metadata files were transferred correctly to the hca-util are they can  proceed with submission creation and validation
+
+## Submission review and validation
+Data and metadata in a managed access submission are considered sensitive information and must be kept encrypted. Unlike in the case of open access datasets, review for a managed access dataset must be done without ever downloading the metadata spreadsheet - or the data - to a non-encrypted location, like a laptop.
+1. Once the metadata spreadsheet is uploaded to the hca-util area a lambda function will automatically trigger the upload of the spreadsheet to the project in ingest.
+2. If the upload fails because ingest cannot process the spreadsheet, get in touch with the contributor to review their submission in a call. The contributor should share their screen and walk through the spreadsheet.
+3. Review the submission for metadata errors and communicate with the contributor to fix them. Ask the contributor to upload the improved spreadsheet to the hca-util area and repeat from step 1. 
+4. Sync data files directly from hca-util to ingest staging bucket \
+`$ hca-util sync s3://org-hca-data-archive-upload-prod/<submission-uuid>`
+5. Add ontology terms were necessary, for example for methods, species and developmental stage.
+6. Validate experimental design with the graph validation step. If there are any errors communicate with the contributor so that they can amend the metadata spreadsheet and upload the improved version to the hca-util area
+
+## Confirm Project data release
+
+Once the Validation for the Project submission is complete:
+1. Notify the data contributor that the data submission is complete
+2. Confirm that they’re happy to proceed to publishing the Project under Managed access
+3. If the contributor wishes to hold the Project private for a period of time, confirm the desired release date and put a reminder in the calendar for that date
+4. If the Project is to be published with the first available release, give an estimate of when they can expect to see the project live on the HCA Data Portal.
+
+## Export
+
+Within the timeframe agreed for the data release: 
+1. Export the project by clicking Export on Project in [HCA Data Repository Ingest service backoffice](https://contribute.data.humancellatlas.org/) and select ‘Export files and metadata’
+2. Once the export is complete, fill out the usual [Data release import form](https://docs.google.com/forms/d/e/1FAIpQLSeokUTa-aVXGDdSNODEYetxezasFKp2oVLz65775lgk5t0D2w/viewform?gxids=7628).
+
+## Verify
+
+Once the dataset is live on the HCA Data Portal: 
+1. Verify that the project is displayed correctly
+2. Send a link to the data contributor so that they may reference it in their publications.

--- a/docs/SOPs/Managed_access/Review_and_export_SOP.md
+++ b/docs/SOPs/Managed_access/Review_and_export_SOP.md
@@ -4,16 +4,16 @@ title: Data and metadata review and export SOP
 parent: Managed access
 grand_parent: SOPs
 nav_order: 5
-last_modified_date: 30/05/2024
+last_modified_date: 04/06/2024
 ---
 
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 
-# Managed access dataset - Data and metadata review and export SOP
+# Managed access project - Data and metadata review and export SOP
 Once the the wrangler has verified that the data and metadata files were transferred correctly to the hca-util are they can  proceed with submission creation and validation
 
 ## Submission review and validation
-Data and metadata in a managed access submission are considered sensitive information and must be kept encrypted. Unlike in the case of open access datasets, review for a managed access dataset must be done without ever downloading the metadata spreadsheet - or the data - to a non-encrypted location, like a laptop.
+Data and metadata in a managed access submission are considered sensitive information and must be kept encrypted. Unlike in the case of open access projects, review for a managed access project must be done without ever downloading the metadata spreadsheet - or the data - to a non-encrypted location, like a laptop.
 1. Once the metadata spreadsheet is uploaded to the hca-util area a lambda function will automatically trigger the upload of the spreadsheet to the project in ingest.
 2. If the upload fails because ingest cannot process the spreadsheet, get in touch with the contributor to review their submission in a call. The contributor should share their screen and walk through the spreadsheet.
 3. Review the submission for metadata errors and communicate with the contributor to fix them. Ask the contributor to upload the improved spreadsheet to the hca-util area and repeat from step 1. 
@@ -38,6 +38,6 @@ Within the timeframe agreed for the data release:
 
 ## Verify
 
-Once the dataset is live on the HCA Data Portal: 
+Once the project is live on the HCA Data Portal: 
 1. Verify that the project is displayed correctly
 2. Send a link to the data contributor so that they may reference it in their publications.

--- a/docs/SOPs/Update_schema_ontology/Update_schema_ontology.md
+++ b/docs/SOPs/Update_schema_ontology/Update_schema_ontology.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Update schema & ontology
-nav_order: 7
+nav_order: 8
 parent: SOPs
 has_children: true
 ---

--- a/docs/SOPs/contributor_communication_SOP.md
+++ b/docs/SOPs/contributor_communication_SOP.md
@@ -2,7 +2,7 @@
 layout: default
 title: Contributor communication
 parent: SOPs
-nav_order: 5
+nav_order: 6
 ---
 <script src="https://kit.fontawesome.com/fc66878563.js" crossorigin="anonymous"></script>
 # Contributor communication SOP

--- a/docs/technology_types_guide/technology_types_guide.md
+++ b/docs/technology_types_guide/technology_types_guide.md
@@ -3,7 +3,7 @@ layout: default
 title: Technology Types Guide
 has_children: true
 parent: SOPs
-nav_order: 8
+nav_order: 9
 ---
 # Technology Types Guide
 Here are some guidelines for wrangling specific technologies.


### PR DESCRIPTION
Having the SOPs for managed access datasets in place is essential so that wranglers can consistently follow the correct steps and for security auditing purposes. 

The SOPs have already been reviewed by Tony, and we are publishing them through github to version them and make them accessible.

See [ticket](https://app.zenhub.com/workspaces/submissions-65a6655b05a44315f6caa232/issues/zh/77) for more context

 
