### PR TITLE
Replace zenhub references with github Projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor_project_tracker.md
+++ b/.github/ISSUE_TEMPLATE/contributor_project_tracker.md
@@ -4,6 +4,7 @@ about: Create a ticket for tracking key events of an in-progress project from a 
 title: ''
 labels: dataset,contributor dataset
 assignees: ''
+projects: "ebi-ait/12"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/dataset_task.md
+++ b/.github/ISSUE_TEMPLATE/dataset_task.md
@@ -4,6 +4,7 @@ about: Create a ticket for a dataset-related wrangler task.
 title: dataset problem - HCADataSetXYZ
 labels: dataset, operations, task
 assignees: ''
+projects: "ebi-ait/12"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/dataset_task.md
+++ b/.github/ISSUE_TEMPLATE/dataset_task.md
@@ -4,7 +4,7 @@ about: Create a ticket for a dataset-related wrangler task.
 title: dataset problem - HCADataSetXYZ
 labels: dataset, operations, task
 assignees: ''
-projects: "ebi-ait/12"
+projects: "ebi-ait/11"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/onboarding_process.md
+++ b/.github/ISSUE_TEMPLATE/onboarding_process.md
@@ -15,7 +15,7 @@ Begin with a introductory tasks and introduction. This could be something like:
 Welcome to the HCA DCP! We are pleased to introduce you to the data wrangling team. Before beginning to work by yourself, you'll be asked to complete a set of tasks and meetings. These will guide you through both the general and specifics of your role, and it will help us make sure you understand how we work in the team. Your introductory tasks are:
 
 - [ ] Read the [onboarding document](https://ebi-ait.github.io/hca-ebi-wrangler-central/ebi-wrangler-onboarding.html).
-- [ ] Move this ticket from "to do" to "in progress" Pipeline in ZenHub.
+- [ ] Move this ticket from "to do" to "in progress" Status in Github Projects.
 - [ ] Create an issue for each [general task](#general-tasks) and link it to this epic.
 - [ ] Clone all the basic repos to your computer (look at the [onboarding document](https://ebi-ait.github.io/hca-ebi-wrangler-central/ebi-wrangler-onboarding.html) for more information)
 - [ ] Locate all the documents regarding SOPs. You don't need to read them for now, but make sure to know where they are (Via notes, bookmarking, etc)

--- a/.github/ISSUE_TEMPLATE/published_project_tracker.md
+++ b/.github/ISSUE_TEMPLATE/published_project_tracker.md
@@ -4,6 +4,7 @@ about: Create a ticket for tracking key events of an in-progress project.
 title: ''
 labels: dataset,publication
 assignees: ''
+projects: "ebi-ait/12"
 
 ---
 

--- a/docs/SOPs/After_export/update_a_project_SOP.md
+++ b/docs/SOPs/After_export/update_a_project_SOP.md
@@ -37,7 +37,7 @@ Things that can’t be done: (?)
 * Analysed datasets - OPEN QUESTION: Should be coordinated with the Matrix Service/DataOps?
 
 ## Procedure
-1. The identifier of the issue reopens the project tracker ticket for that project if it has been closed and moves it to the 'Needs Update' pipeline of the [`Dataset wrangling status`](https://github.com/orgs/ebi-ait/projects/12) Github Projects board and makes a comment that contains the following information, (if not already specified in the ticket body)
+1. The identifier of the issue reopens the project tracker ticket for that project if it has been closed, adds the label 'needsUpdate' and moves it to an appropriate pipeline of the [`Dataset wrangling status`](https://github.com/orgs/ebi-ait/projects/12) Github Projects board and makes a comment that contains the following information, (if not already specified in the ticket body)
     1. project full name
     1. project short name 
     1. Project UUID

--- a/docs/SOPs/After_export/update_a_project_SOP.md
+++ b/docs/SOPs/After_export/update_a_project_SOP.md
@@ -37,7 +37,7 @@ Things that can’t be done: (?)
 * Analysed datasets - OPEN QUESTION: Should be coordinated with the Matrix Service/DataOps?
 
 ## Procedure
-1. The identifier of the issue reopens the project tracker ticket for that project if it has been closed and moves it to the 'Needs Update' pipeline of the [`Dataset wrangling status`](https://github.com/ebi-ait/hca-ebi-wrangler-central#workspaces/dataset-wrangling-status-5f994cb88e0805001759d2e9/board?repos=261790554) Zenhub board and makes a comment that contains the following information, (if not already specified in the ticket body)
+1. The identifier of the issue reopens the project tracker ticket for that project if it has been closed and moves it to the 'Needs Update' pipeline of the [`Dataset wrangling status`](https://github.com/orgs/ebi-ait/projects/12) Github Projects board and makes a comment that contains the following information, (if not already specified in the ticket body)
     1. project full name
     1. project short name 
     1. Project UUID

--- a/docs/SOPs/Introduction/dataset_wrangling_SOP.md
+++ b/docs/SOPs/Introduction/dataset_wrangling_SOP.md
@@ -36,21 +36,16 @@ New contributors will almost always contact us via the wranglers email list. Whe
 
 ### Tracking wrangling progress
 
-Wrangling progress is tracked primarily through movement of the `project tracker ticket` through the pipelines on the [Dataset wrangling status](https://github.com/ebi-ait/hca-ebi-wrangler-central#workspaces/dataset-wrangling-status-5f994cb88e0805001759d2e9/board?repos=261790554) Zenhub Board. 
+Wrangling progress is tracked primarily through movement of the `project tracker ticket` through the status on the [Dataset wrangling status](https://github.com/orgs/ebi-ait/projects/12/) Github Projects Board. 
 
-| Pipeline            | When                                   | Explanation                                                                                                                                 |
+| Status            | When                                   | Explanation                                                                                                                                 |
 |:---------------------|:----------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------|
-| New Issues          | Auto-placed                            | This pipeline is where issues automatically end up but issues shouldn't stay here for long |
-| Queued for Wrangling      | When created                           | Issues should be placed here when they are created but before a wrangler actively starts working on it |
-| Wrangling           | When in progress                       | The primary wrangler moves the tracker ticket here when they have started working on it |
-| Secondary reviewing | When review starts                     | The secondary wrangler moves the tracker ticket here when they start reviewing |
-| Finalising          | When reviewed but needs changed        | The primary wrangler moves the tracker ticket here when applying changes to secondary wrangled datasets |
-| Archiving           | When archiving process starts          | The primary wrangler moves the tracker ticket here when Archiving starts (if required), if already archived would skip to ready for export |
-| Needs update        | If project needs an update             | A wrangler moves the tracker ticket here if the project requires some kind of update |
+| Todo      | When created or if project needs update          | Issues should be placed here when they are created but before a wrangler actively starts working on it or if project requires some kind of update |
 | Stalled             | If project becomes stuck               | If project spends more than 2 weeks with no progress, the ticket should be moved here and label applied to indicate reason  |
-| Exported in the DCP            | When finished                          | The primary wrangler moves the ticket here to indicate the project is exported to the DCP.  |
-| Verified in data browser | When project has been verified in the data browser | The primary wrangler moves the ticket here to indicate that it has been verified in the data browser. |
-| CellxGene | When working on wrangling to CellxGene | The primary wrangler moves the ticket here to indicate that the project is actively being wrangled to CellxGene |
+| Wrangling           | When in progress                       | The primary wrangler moves the tracker ticket here when they have started working on it |
+| Review | When review starts                     | The secondary wrangler moves the tracker ticket here when they start reviewing |
+| Verify            | When finished                          | The primary wrangler moves the ticket here to indicate the project is exported to the DCP and is waiting to be verified.  |
+| Done | When project has been verified in the data browser | The primary wrangler moves the ticket here to indicate that it has been verified in the data browser. |
 
 
 [Labels](https://github.com/ebi-ait/hca-ebi-wrangler-central/labels) are also applied to tickets to provide further information about the ticket. Definitions for each label and when they should be applied can be [found here](https://github.com/ebi-ait/hca-ebi-wrangler-central/labels).
@@ -444,7 +439,7 @@ If you want to run the tests locally, or suggest a new test/report a bug, please
 
 ## Secondary Review
 
-Once the spreadsheet has passed both phases of validation, the primary wrangler should ask another wrangler in the team to review the spreadsheet and suggest any required edits or updates. Once someone asks for secondary review, they should move the ticket to the `Secondary wrangling` pipeline on the tracking board.
+Once the spreadsheet has passed both phases of validation, the primary wrangler should ask another wrangler in the team to review the spreadsheet and suggest any required edits or updates. Once someone asks for secondary review, they should move the ticket to the `Review` status on the tracking board.
 
 If any edits or updates are made, the existing submission in ingest will need to be deleted and the new spreadsheet uploaded in its place.
 
@@ -452,7 +447,7 @@ If any changes may have also affected the linking in the spreadsheet it should a
 
 A detailed guide to performing secondary review [can be found here](secondary_review_SOP).
 
-Once both the Primary and Secondary wrangler are happy with the submission and it is valid in ingest, move the dataset tracker ticket to the `Ready to Export` pipeline of the [Dataset wrangling board](https://github.com/ebi-ait/hca-ebi-wrangler-central#workspaces/dataset-wrangling-status-5f994cb88e0805001759d2e9/board?repos=261790554) and change the `hca_status` to 'ready to export' in the [Dataset Tracking Sheet](https://docs.google.com/spreadsheets/d/1rm5NZQjE-9rZ2YmK_HwjW-LgvFTTLs7Q6MzHbhPftRE/edit#gid=0). The data files can now be moved from the contributor bucket into the ingest upload area.
+Once both the Primary and Secondary wrangler are happy with the submission and it is valid in ingest, the data files can now be moved from the contributor bucket into the ingest upload area.
 
 ## Transferring data from `hca-util` upload area to ingest upload area
 

--- a/docs/SOPs/Metadata_spreadsheet/wrangling_best_practices.md
+++ b/docs/SOPs/Metadata_spreadsheet/wrangling_best_practices.md
@@ -103,7 +103,7 @@ As such, this document should be an updated **living document** containing the b
     * Specimen (single cell/nuclei OR bulk)
     * Cell line
     * Organoid
-    * Cell suspension (WIP; please see this [ticket](https://app.zenhub.com/workspaces/operations-5fa2d8f2df78bb000f7fb2b5/issues/ebi-ait/hca-ebi-wrangler-central/927))
+    * Cell suspension (WIP; please see this [ticket](https://github.com/ebi-ait/hca-ebi-wrangler-central/issues/927))
     
 ### Organoids
 

--- a/docs/ebi-wrangler-onboarding.md
+++ b/docs/ebi-wrangler-onboarding.md
@@ -282,7 +282,7 @@ Repositories you will mainly use:
 - [`Operations Planning Notes`](https://docs.google.com/document/d/1O2nCBtnFY-AWh_1_s188xLTyvaZpwbUUp3Pvs_aV_jc/edit#heading=h.usaswk9ioim4) 
 
 #### Wrangling
-- [`Dataset Wrangling Zenhub Board`](https://app.zenhub.com/workspaces/dataset-wrangling-status-5f994cb88e0805001759d2e9/board?repos=261790554) 
+- [`Dataset Wrangling Github Projects Board`](https://github.com/orgs/ebi-ait/projects/12/) 
 - [`HCA Wrangling Datasets SOP`](https://ebi-ait.github.io/hca-ebi-wrangler-central/SOPs/dataset_wrangling_SOP.html) 
 - [`Dataset Brokering Folder`](https://drive.google.com/drive/folders/118kh4wiHmn4Oz9n1-WZueaxm-8XuCMkA) 
 - [`Single Cell Genomics Library Structure`](https://teichlab.github.io/scg_lib_structs/) 
@@ -295,9 +295,12 @@ Repositories you will mainly use:
 
 ### Browser plug-ins
 
-- [Zenhub](https://chrome.google.com/webstore/detail/zenhub-for-github/ogcgkffhplmphkaahpmffcafajaocjbd): used by many of the teams in the DCP as way to implement the SCRUM and Agile methodologies within github. We have a combined [ingest board](https://github.com/ebi-ait/hca-ebi-wrangler-central/edit/master/docs/ebi-wrangler-onboarding.md#workspaces/ingest-dev-5cfe1cb26482e537cf35e8d1/board?repos=249765101,232300832,244611740,261790554,240563208,132741306,237019026,102351002) for tracking all work for the ingest team at EBI. You can play around with visibility to ensure the board is most relevant to your work.
+- [modHeader](https://modheader.com/): Navigate ingest-api via browser, when authorisation token is required. 
+    > Tip: Add "Request URL Filter": .\*://api.ingest.archive.data.humancellatlas.org/.\* to avoid sending header to any website.
 - [Octotree](https://chrome.google.com/webstore/detail/octotree/bkhaagjahfmjljalopjnoealnfndnagc): Adds easier navigation of repos in github
 - JSON viewer of your choice.
+- ~~[Zenhub](https://chrome.google.com/webstore/detail/zenhub-for-github/ogcgkffhplmphkaahpmffcafajaocjbd):~~ Zenhub access has been expired, and we are no longer using it.
+
 
 ### Miscellanea
 


### PR DESCRIPTION
Since we are no longer using Zenhub, here I remove the references of zenhub in our documentation.
- Added the automatic assignment of new wrangling tickets to  the wrangling board (issue_templates)
- replaced references of zenhub with github projects [wrangling board](https://github.com/orgs/ebi-ait/projects/12/)
- added `modHeader` addon as a suggestion in onboarding and removed the zenhub addon suggestion
- replaced pipelines explanation with the new status explanation

